### PR TITLE
Enable centering when search widget is visible

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "command": "center-editor-window.center",
         "key": "ctrl+l",
         "mac": "ctrl+l",
-        "when": "editorTextFocus"
+        "when": "editorTextFocus || findWidgetVisible"
       }
     ],
     "configuration": [


### PR DESCRIPTION
This implements https://github.com/kaiwood/vscode-center-editor-window/issues/8